### PR TITLE
Downgrade Webonyx GraphQL to match Magento

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "magento/module-customer": "^103.0",
         "magento/module-eav": "^102.1",
         "magento/module-store": "^101.1",
-        "webonyx/graphql-php": "^14.5"
+        "webonyx/graphql-php": "^0.13.8"
     },
     "minimum-stability": "stable",
     "repositories": [


### PR DESCRIPTION
Magento uses an older version of the Webonyx GraphQL package, which
needed a downgrade is this module to properly work.