### PR TITLE
Make housenumber optional

### DIFF
--- a/src/Service/Fetcher.php
+++ b/src/Service/Fetcher.php
@@ -92,10 +92,13 @@ class Fetcher
                 'actief'
             ],
             'filters' => [
-                'postcode' => $postcode,
-                'huisnummer' => $houseNumber
+                'postcode' => $postcode
             ]
         ];
+
+        if (!empty($houseNumber)) {
+            $params['filters']['huisnummer'] = $houseNumber;
+        }
 
         return $this->fetch($params);
     }


### PR DESCRIPTION
When not entering a house number, it should still be possible to
fetch results. This has been made optional.