### PR TITLE
Remove spaces from postcode field

### DIFF
--- a/src/Service/Fetcher.php
+++ b/src/Service/Fetcher.php
@@ -92,7 +92,7 @@ class Fetcher
                 'actief'
             ],
             'filters' => [
-                'postcode' => $postcode
+                'postcode' => str_replace(' ', '', $postcode)
             ]
         ];
 


### PR DESCRIPTION
Since it's possible to use a space within the postcode, but the
API doesn't support that, the space will be removed from the postcode
when fetching the result.